### PR TITLE
/data owned by admin, and bitcoin user creation belongs in the Bitcoi…

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -90,22 +90,39 @@ This is a precaution to make sure that this is an official release and not a mal
 🔍 *Verifying signed software is important, not only for Bitcoin.
 You can read more on [How to securely install Bitcoin](https://medium.com/@lukedashjr/how-to-securely-install-bitcoin-9bfeca7d3b2a){:target="_blank"} by Luke-Jr.*
 
+### Create the bitcoin user
+
+The Bitcoin Core application will run in the background as a daemon and use the separate user “bitcoin” for security reasons.
+This user does not have admin rights and cannot change the system configuration.
+
+* Create the user bitcoin
+
+  ```sh
+  $ sudo adduser --gecos "" --disabled-password bitcoin
+  ```
+
+* Add the user "admin" to the group "bitcoin" as well
+
+  ```sh
+  $ sudo adduser admin bitcoin
+  ```
 
 ### Create data folder
 
 Bitcoin Core uses by default the folder `.bitcoin` in the user's home.
 Instead of creating this directory, we create a data directory in the general data location `/data` and link to it.
 
-* Switch to user "bitcoin"
-
-  ```sh
-  $ sudo su - bitcoin
-  ```
-
 * Create the Bitcoin data folder
 
   ```sh
   $ mkdir /data/bitcoin
+  $ chown bitcoin:bitcoin /data/bitcoin
+  ```
+
+* Switch to user "bitcoin"
+
+  ```sh
+  $ sudo su - bitcoin
   ```
 
 * Create the symbolic link `.bitcoin` that points to that directory

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -24,17 +24,9 @@ Let's start with the configuration.
 
 ---
 
-## Add users
+## Add the admin user (and log in with it)
 
 We will use the primary user "admin" instead of "pi" to make this guide more universal.
-
-* Instruct your shell (the command line) to always use the default language settings.
-  This prevents annoying error messages
-
-  ```sh
-  $ echo "export LC_ALL=C" >> ~/.bashrc
-  $ source ~/.bashrc
-  ```
 
 * Create a new user called "admin" with your `password [A]`
 
@@ -47,80 +39,31 @@ We will use the primary user "admin" instead of "pi" to make this guide more uni
   ```sh
   $ sudo adduser admin sudo
   ```
+  
 
-The Bitcoin Core application will run in the background (as a "daemon") and use the separate user “bitcoin” for security reasons.
-This user does not have admin rights and cannot change the system configuration.
-
-* Create the user "bitcoin"
+* Exit your current "pi" user session and exit SSH
 
   ```sh
-  $ sudo adduser --gecos "" --disabled-password bitcoin
+  $ exit
   ```
 
-* Add the user "admin" to the group "bitcoin" as well
+* Create a new connection with the `admin` user
 
-  ```sh
-  $ sudo adduser admin bitcoin
-  ```
-
----
-
-## Check USB3 drive performance
-
-A performant USB3 drive is essential for your node.
-The Raspberry Pi 4 supports these out of the box, but is a bit picky.
-Some USB3 adapters for external drives are not compatible and need a workaround to be usable.
-
-Let's check if your drive works well as-is, or if additional configuration is needed.
-
-* Install the software to measure the performance of your drive
-
-  ```sh
-  $ sudo apt update
-  $ sudo apt install hdparm
-  ```
-
-* Your external disk should be connected as `/dev/sda`.
-  Check if this is the case by listing the names of connected block devices
-
-  ```sh
-  $ lsblk -pli
-  ```
-
-* Measure the speed of your external drive
-
-  ```sh
-  $ sudo hdparm -t --direct /dev/sda
-  > Timing O_DIRECT disk reads: 932 MB in  3.00 seconds = 310.23 MB/sec
-  ```
-
-If the measured speed is more than 50 MB/s, you're good, no further action needed.
-
-If the speed of your USB3 drive is not acceptable, we need to configure the USB driver to ignore the UAS interface.
-
-Check the [Fix bad USB3 performance](troubleshooting.md#fix-bad-usb3-performance) entry in the Troubleshooting guide to learn how.
-
----
-
-## System update
-
-Exit your current "pi" user session and exit SSH
-
-```sh
-$ exit
-```
-
-It is important to keep the system up-to-date with security patches and application updates.
-The “Advanced Packaging Tool” (apt) makes this easy.
-
-* Log in again using SSH, but now with the user "admin" and  your `password [A]`
+* Log in again using SSH (see [Access with Secure Shell](remote-access.html#access-with-secure-shell) section), but now with the user "admin" and your `password [A]`
 
   ```sh
   $ ssh admin@raspibolt.local
   ```
 
-  To change the system configuration and files that don't belong to the "admin", you have to prefix commands with `sudo`.
-  You will be prompted to enter your admin password from time to time for increased security.
+To change the system configuration and files that don't belong to user "admin", you have to prefix commands with `sudo`.
+You will be prompted to enter your admin password from time to time for increased security.
+
+---
+
+## System update
+
+It is important to keep the system up-to-date with security patches and application updates.
+The “Advanced Packaging Tool” (apt) makes this easy.
 
 * Instruct your shell to always use the default language settings.
   This prevents annoying error messages.
@@ -147,17 +90,52 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 
 ---
 
+## Check USB3 drive performance
+
+A performant USB3 drive is essential for your node.
+The Raspberry Pi 4 supports these out of the box, but is a bit picky.
+Some USB3 adapters for external drives are not compatible and need a workaround to be usable.
+
+Let's check if your drive works well as-is, or if additional configuration is needed.
+
+* Install the software to measure the performance of your drive
+
+  ```sh
+  $ sudo apt install hdparm
+  ```
+
+* Your external disk should be connected as `/dev/sda`.
+  Check if this is the case by listing the names of connected block devices
+
+  ```sh
+  $ lsblk -pli
+  ```
+
+* Measure the speed of your external drive
+
+  ```sh
+  $ sudo hdparm -t --direct /dev/sda
+  > Timing O_DIRECT disk reads: 932 MB in  3.00 seconds = 310.23 MB/sec
+  ```
+
+If the measured speed is more than 50 MB/s, you're good, no further action needed.
+
+If the speed of your USB3 drive is not acceptable, we need to configure the USB driver to ignore the UAS interface.
+
+Check the [Fix bad USB3 performance](troubleshooting.md#fix-bad-usb3-performance) entry in the Troubleshooting guide to learn how.
+
+---
+
 ## Data directory
 
 We'll store all application data in the dedicated directory `/data/`.
 This allows for better security because it's not inside any user's home directory.
 Additionally, it's easier to move that directory somewhere else, for instance to a separate drive, as you can just mount any storage option to `/data/`.
 
-* Create the directory and make user "bitcoin" its owner
+* Create the data directory
 
   ```sh
   $ sudo mkdir /data
-  $ sudo chown bitcoin:bitcoin /data
   ```
 
 ---


### PR DESCRIPTION
…n section (#904)

* /data owned by admin, and bitcoin user creation belongs in the Bitcoin section

* no use in switching to user admin as this is already the case

* specify that the bitcoin folder has been created by admin

* removed the second export LC_ALL=C which is unnecessary

* no need to chown /data to admin as this user has created it directly

* close shell in pi context and open a new one with admin

* minor fixes bitcoin-core.md

* use chown format "user:group" (more clear, less error-prone)
* wording fixes

* consistency improvements system-configuration.md

* move "logout" / "login" instructions up from section System update
* Remove first config of LC_ALL for user "pi"
* Re-add second config of LC_ALL for user "admin"
* Re-add 'sudo' explanation
* minor wording adjustments

* move "Check USB3 drive performance" down

Moving the section "Check USB3 drive performance" down fixes:
* setting LC_ALL too late (the first 'apt update' and 'apt install hdparm' commands 
  might already show error messages)
* duplicate use of 'apt update'

Co-authored-by: Stadicus <root@stadicus.com>

#### What

What is the reason of this change?

### Why

Why is this change important?

#### How

How was this change accomplished?

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

#### Animated GIF (optional)

Add some snazz if you feel like it :)
